### PR TITLE
add ability to name cli server

### DIFF
--- a/src/many-cli/src/main.rs
+++ b/src/many-cli/src/main.rs
@@ -146,6 +146,10 @@ struct ServerOpt {
     /// The address and port to bind to for the MANY Http server.
     #[clap(long, short, default_value = "127.0.0.1:8000")]
     addr: SocketAddr,
+
+    /// The name to give the server.
+    #[clap(long, short, default_value = "many-server")]
+    name: String,
 }
 
 #[derive(Parser)]
@@ -398,7 +402,7 @@ fn main() {
                 .expect("Could not generate identity from PEM file.");
 
             let many = ManyServer::simple(
-                "many-server",
+                o.name,
                 key,
                 Some(std::env!("CARGO_PKG_VERSION").to_string()),
                 None,


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->

Currently the server subcommand has a hardcoded "many-server" string for the server name.
The new behavior adds the --name option to the server subcommand and allows the user to name the cli server instance.

## Related Issue

<!-- Pull Requests should relate to an open Issue. -->
<!-- If this PR fixes a bug or introduces a new feature, please create an Issue first. -->

Fixes # (issue)

## Testing

<!-- Please describe how you tested your changes. -->
<!-- Include details of your testing environment and the tests you ran. -->

## Breaking Changes (if applicable)

<!-- Please describe any breaking changes and your plan to handle them. -->
<!-- A breaking change is a change to this module's API that might cause consumers to fail. -->
<!-- e.g. modifying required parameters, renaming a public method, changing a response type -->

## Screenshots (if applicable)
![Screen Shot 2022-05-18 at 2 16 35 PM](https://user-images.githubusercontent.com/20386670/169138896-957c1933-f125-4f61-80bf-ce68ffc6d056.png)

## Checklist:

- [X] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
